### PR TITLE
Abstract sample and project parsing logic from __init__.py

### DIFF
--- a/grabseqslib/__init__.py
+++ b/grabseqslib/__init__.py
@@ -5,8 +5,8 @@ import pandas as pd
 
 from pathlib import Path
 from grabseqslib.sra import process_sra, add_sra_subparser
-from grabseqslib.imicrobe import get_imicrobe_acc_metadata, download_imicrobe_sample, add_imicrobe_subparser
-from grabseqslib.mgrast import get_mgrast_acc_metadata, download_mgrast_sample, add_mgrast_subparser
+from grabseqslib.imicrobe import process_imicrobe, add_imicrobe_subparser
+from grabseqslib.mgrast import process_mgrast, add_mgrast_subparser
 
 def main():
     '''
@@ -59,36 +59,10 @@ def main():
         metadata_agg = process_sra(args, zip_func)
 
     elif repo == "MG-RAST":
-        for rast_proj in args.rastid:
-            # get targets
-            target_list = get_mgrast_acc_metadata(rast_proj)
+        metadata_agg = process_mgrast(args, zip_func)
 
-            for target in target_list:
-                # get samples and/or metadata
-                metadata_agg = download_mgrast_sample(target,
-                                                      args.retries,
-                                                      args.threads,
-                                                      args.outdir,
-                                                      args.force,
-                                                      args.list,
-                                                      not (args.metadata == ""),
-                                                      metadata_agg, zip_func)
     elif repo == "iMicrobe":
-        for imicrobe_identifier in args.imicrobeid:
-            # get targets
-            target_list = get_imicrobe_acc_metadata(imicrobe_identifier)
-
-            for target in target_list:
-                # get samples and/or metadata
-                metadata_agg = download_imicrobe_sample(target,
-                                                        args.retries,
-                                                        args.threads,
-                                                        args.outdir,
-                                                        args.force,
-                                                        args.list,
-                                                        not (args.metadata == ""),
-                                                        metadata_agg, zip_func)
-
+        metadata_agg = process_imicrobe(args, zip_func)
 
     # Handle metadata
     if args.metadata != "":

--- a/grabseqslib/__init__.py
+++ b/grabseqslib/__init__.py
@@ -4,7 +4,7 @@ import os, sys, argparse, warnings, shutil
 import pandas as pd
 
 from pathlib import Path
-from grabseqslib.sra import process_sra
+from grabseqslib.sra import process_sra, add_sra_subparser
 from grabseqslib.imicrobe import get_imicrobe_acc_metadata, download_imicrobe_sample, add_imicrobe_subparser
 from grabseqslib.mgrast import get_mgrast_acc_metadata, download_mgrast_sample, add_mgrast_subparser
 
@@ -56,34 +56,7 @@ def main():
 
     # Download samples
     if repo == "SRA":
-        # check deps
         metadata_agg = process_sra(args, zip_func)
-        #dep_list = ["fastq-dump", "fasterq-dump"]
-        #deps_have = [shutil.which(dep) for dep in dep_list]
-        #if (not deps_have[0]) and (not deps_have[1]): # no sra-tools
-        #    print("Neither fastq-dump nor fasterq-dump found; one is required. Please install sra-tools")
-        #    sys.exit(1)
-        #elif not deps_have[1]:
-        #    use_fastq_dump = True
-        #else:
-        #    use_fastq_dump = args.fastqdump
-
-        #for sra_identifier in args.id:
-            # get targets and metadata
-        #    acclist, metadata_agg = get_sra_acc_metadata(sra_identifier,
-        #                                                 args.outdir, 
-        #                                                 args.list, 
-        #                                                 not args.SRR_parsing, 
-        #                                                 metadata_agg)
-        #    for acc in acclist:
-                # get samples
-        #        run_fasterq_dump(acc,
-        #                         args.retries,
-        #                         args.threads,
-        #                         args.outdir,
-        #                         args.force,
-        #                         use_fastq_dump,
-        #                         zip_func)
 
     elif repo == "MG-RAST":
         for rast_proj in args.rastid:

--- a/grabseqslib/__init__.py
+++ b/grabseqslib/__init__.py
@@ -4,7 +4,7 @@ import os, sys, argparse, warnings, shutil
 import pandas as pd
 
 from pathlib import Path
-from grabseqslib.sra import get_sra_acc_metadata, run_fasterq_dump, add_sra_subparser
+from grabseqslib.sra import process_sra
 from grabseqslib.imicrobe import get_imicrobe_acc_metadata, download_imicrobe_sample, add_imicrobe_subparser
 from grabseqslib.mgrast import get_mgrast_acc_metadata, download_mgrast_sample, add_mgrast_subparser
 
@@ -45,8 +45,6 @@ def main():
         except AttributeError:
             repo = "SRA"
 
-    # Download samples!
-    metadata_agg = None
     # Check deps
     zip_func = "gzip"
     if shutil.which("pigz"):
@@ -54,34 +52,38 @@ def main():
     else:
         print("pigz not found, using gzip")
 
+    metadata_agg = None
+
+    # Download samples
     if repo == "SRA":
         # check deps
-        dep_list = ["fastq-dump", "fasterq-dump"]
-        deps_have = [shutil.which(dep) for dep in dep_list]
-        if (not deps_have[0]) and (not deps_have[1]): # no sra-tools
-            print("Neither fastq-dump nor fasterq-dump found; one is required. Please install sra-tools")
-            sys.exit(1)
-        elif not deps_have[1]:
-            use_fastq_dump = True
-        else:
-            use_fastq_dump = args.fastqdump
+        metadata_agg = process_sra(args, zip_func)
+        #dep_list = ["fastq-dump", "fasterq-dump"]
+        #deps_have = [shutil.which(dep) for dep in dep_list]
+        #if (not deps_have[0]) and (not deps_have[1]): # no sra-tools
+        #    print("Neither fastq-dump nor fasterq-dump found; one is required. Please install sra-tools")
+        #    sys.exit(1)
+        #elif not deps_have[1]:
+        #    use_fastq_dump = True
+        #else:
+        #    use_fastq_dump = args.fastqdump
 
-        for sra_identifier in args.id:
+        #for sra_identifier in args.id:
             # get targets and metadata
-            acclist, metadata_agg = get_sra_acc_metadata(sra_identifier,
-                                                         args.outdir, 
-                                                         args.list, 
-                                                         not args.SRR_parsing, 
-                                                         metadata_agg)
-            for acc in acclist:
+        #    acclist, metadata_agg = get_sra_acc_metadata(sra_identifier,
+        #                                                 args.outdir, 
+        #                                                 args.list, 
+        #                                                 not args.SRR_parsing, 
+        #                                                 metadata_agg)
+        #    for acc in acclist:
                 # get samples
-                run_fasterq_dump(acc,
-                                 args.retries,
-                                 args.threads,
-                                 args.outdir,
-                                 args.force,
-                                 use_fastq_dump,
-                                 zip_func)
+        #        run_fasterq_dump(acc,
+        #                         args.retries,
+        #                         args.threads,
+        #                         args.outdir,
+        #                         args.force,
+        #                         use_fastq_dump,
+        #                         zip_func)
 
     elif repo == "MG-RAST":
         for rast_proj in args.rastid:

--- a/grabseqslib/imicrobe.py
+++ b/grabseqslib/imicrobe.py
@@ -30,6 +30,27 @@ def add_imicrobe_subparser(subparser):
     parser_imicrobe.add_argument('-l', dest="list", action="store_true",
                 help="list (but do not download) samples to be grabbed")
 
+def process_imicrobe(args, zip_func):
+    """
+    Top-level function to process iMicrobe download. Returns aggregated metadata.
+    """
+    metadata_agg = None
+    for imicrobe_identifier in args.imicrobeid:
+        # get targets
+        target_list = get_imicrobe_acc_metadata(imicrobe_identifier)
+
+        for target in target_list:
+            # get samples and/or metadata
+            metadata_agg = download_imicrobe_sample(target,
+                                                    args.retries,
+                                                    args.threads,
+                                                    args.outdir,
+                                                    args.force,
+                                                    args.list,
+                                                    not (args.metadata == ""),
+                                                    metadata_agg, zip_func)
+    return metadata_agg
+
 def get_imicrobe_acc_metadata(pacc):
     """
     Function to get list of iMicrobe sample accession numbers from a particular

--- a/grabseqslib/mgrast.py
+++ b/grabseqslib/mgrast.py
@@ -27,6 +27,26 @@ def add_mgrast_subparser(subparser):
     parser_rast.add_argument('-l', dest="list", action="store_true",
                 help="list (but do not download) samples to be grabbed")
 
+def process_mgrast(args, zip_func):
+    """
+    Top-level function to process MG-RAST download. Returns aggregated metadata.
+    """
+    metadata_agg = None
+    for rast_proj in args.rastid:
+        # get targets
+        target_list = get_mgrast_acc_metadata(rast_proj)
+        for target in target_list:
+            # get samples and/or metadata
+            metadata_agg = download_mgrast_sample(target,
+                                                  args.retries,
+                                                  args.threads,
+                                                  args.outdir,
+                                                  args.force,
+                                                  args.list,
+                                                  not (args.metadata == ""),
+                                                  metadata_agg, zip_func)
+    return metadata_agg
+
 def get_mgrast_acc_metadata(pacc):
     """
     Function to get list of MG-RAST sample accession numbers from a particular 

--- a/grabseqslib/sra.py
+++ b/grabseqslib/sra.py
@@ -1,4 +1,4 @@
-import requests, time
+import requests, time, shutil, sys
 import pandas as pd
 from io import StringIO
 from subprocess import call


### PR DESCRIPTION
This PR moves the logic for looping through sample/project accessions to their corresponding submodules--this is a design decision that I think makes it easier to understand the code, since now all the download logic is in the same place/module.