### PR TITLE
Allow custom fast(er)qdump args

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - run: bash .circleci/setup.sh
-      - run: bash tests/run_tests.bash -i -d $HOME
+      - run: bash tests/run_tests.bash -i -m -v -d $HOME
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - run: bash .circleci/setup.sh
-      - run: bash tests/run_tests.bash -i -m -v -d $HOME
+      - run: bash tests/run_tests.bash -i -d $HOME
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you'd like to do a dry run and only get a list of samples that will be downlo
 
 If you'd like to pass your own arguments to `fasterq-dump` to get data in a slightly different format, you can do so like this:
 
-    grabseqs sra SRP####### -r 0 --custom
+    grabseqs sra SRP####### -r 0 --custom_fqdump_args="--split-spot"
 
 Full usage:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ If you'd like to do a dry run and only get a list of samples that will be downlo
     
     grabseqs sra -l SRP########
 
+If you'd like to pass your own arguments to `fasterq-dump` to get data in a slightly different format, you can do so like this:
+
+    grabseqs sra SRP####### -r 0 --custom
 
 Full usage:
 
@@ -75,6 +78,8 @@ Full usage:
       -l                list (but do not download) samples to be grabbed
       --parse_run_ids   parse SRR/ERR identifers (do not pass straight to fasterq-
                         dump)
+      --custom_fqdump_args CUSTOM_FQD_ARGS
+                        "string" containing args to pass to fastq-dump
       --use_fastq_dump  use legacy fastq-dump instead of fasterq-dump (no
                         multithreaded downloading)
       
@@ -110,7 +115,8 @@ If you use conda, these will be installed for you!
 ## Changelog
 
 **Dev version (not yet released)**
-
+ - Allow users to pass custom args to fast(er)q-dump
+ - Minor re-writes of download handling for easier code readability
 
 **0.6.1** (2019-12-20)
  - Validate compressed files (fix #8 and #34)

--- a/conda-recipe/grabseqs/meta.yaml
+++ b/conda-recipe/grabseqs/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "grabseqs" %}
-{% set version = "0.6.1" %}
+{% set version = "0.7.0" %}
 
 package:
   name: "{{ name|lower }}"

--- a/grabseqslib/__init__.py
+++ b/grabseqslib/__init__.py
@@ -22,8 +22,7 @@ def main():
     add_imicrobe_subparser(subpa)
     add_mgrast_subparser(subpa)
 
-    args_with_unknowns = parser.parse_known_args()
-    args = args_with_unknowns[0]
+    args = parser.parse_args()
     # Make output directories if they don't exist
     try:
         if args.outdir != "":
@@ -56,7 +55,7 @@ def main():
 
     # Download samples
     if repo == "SRA":
-        metadata_agg = process_sra(args_with_unknowns, zip_func)
+        metadata_agg = process_sra(args, zip_func)
 
     elif repo == "MG-RAST":
         metadata_agg = process_mgrast(args, zip_func)

--- a/grabseqslib/__init__.py
+++ b/grabseqslib/__init__.py
@@ -15,7 +15,7 @@ def main():
     # Set up parsers
     parser = argparse.ArgumentParser(prog="grabseqs",
          description='Download metagenomic sequences from public datasets.')
-    parser.add_argument('--version', '-v', action='version', version='%(prog)s 0.6.1')
+    parser.add_argument('--version', '-v', action='version', version='%(prog)s 0.7.0')
     subpa = parser.add_subparsers(help='repositories available')
 
     add_sra_subparser(subpa)

--- a/grabseqslib/__init__.py
+++ b/grabseqslib/__init__.py
@@ -22,8 +22,8 @@ def main():
     add_imicrobe_subparser(subpa)
     add_mgrast_subparser(subpa)
 
-    args = parser.parse_args()
-
+    args_with_unknowns = parser.parse_known_args()
+    args = args_with_unknowns[0]
     # Make output directories if they don't exist
     try:
         if args.outdir != "":
@@ -56,7 +56,7 @@ def main():
 
     # Download samples
     if repo == "SRA":
-        metadata_agg = process_sra(args, zip_func)
+        metadata_agg = process_sra(args_with_unknowns, zip_func)
 
     elif repo == "MG-RAST":
         metadata_agg = process_mgrast(args, zip_func)

--- a/grabseqslib/sra.py
+++ b/grabseqslib/sra.py
@@ -169,10 +169,10 @@ def run_fasterq_dump(acc, retries = 2, threads = 1, loc='', force=False, fastqdu
             retcode = call(cmd)
             rgzip = 0
             if retcode == 0:
-                # zip all possible output files for that acc
-                fnames = build_paths(acc, loc, False) + build_paths(acc, loc, True)
-                rgzip = gzip_files(fnames, zip_func, threads)
-
+                if not fastqdump:
+                    # zip all possible output files for that acc
+                    fnames = build_paths(acc, loc, False) + build_paths(acc, loc, True)
+                    rgzip = gzip_files(fnames, zip_func, threads)
                 if rgzip == 0:
                     if check_existing(loc, acc) != False:
                         break

--- a/grabseqslib/sra.py
+++ b/grabseqslib/sra.py
@@ -4,12 +4,14 @@ from io import StringIO
 from subprocess import call
 from grabseqslib.utils import check_existing, build_paths, gzip_files
 
-def process_sra(args, zip_func):
+def process_sra(args_with_unknowns, zip_func):
     """
     High-level logic for SRA download processing. Takes
     `args` from grabseqslib argument parser and `zip_func`
     """
     # check deps
+    args = args_with_unknowns[0]
+    unknown_args = args_with_unknowns[1] + [""] #add empty string in case user wants to run without args
     dep_list = ["fastq-dump", "fasterq-dump"]
     deps_have = [shutil.which(dep) for dep in dep_list]
     if (not deps_have[0]) and (not deps_have[1]): # no sra-tools
@@ -37,6 +39,7 @@ def process_sra(args, zip_func):
                              args.outdir,
                              args.force,
                              use_fastq_dump,
+                             args.custom_fqd_args*unknown_args, #empty list if args.custom_fqd_args is False
                              zip_func)
 
     return metadata_agg
@@ -72,6 +75,9 @@ def add_sra_subparser(subparser):
                                 help="parse SRR/ERR identifers (do not pass straight to fasterq-dump)")
     parser_sra.add_argument("--use_fastq_dump", dest="fastqdump", action="store_true",
                 help="use legacy fastq-dump instead of fasterq-dump (no multithreaded downloading)")
+    parser_sra.add_argument("--custom_fqdump_args", dest="custom_fqd_args", action="store_true",
+                help="pass unknown args to fast(er)q-dump. NOTE: Use full arg names\nfrom sra-tools to avoid conflicts!")
+
     # LEGACY: this will be removed in the next major version as this is now default.
     parser_sra.add_argument('--no_parsing', dest="no_SRR_parsing", action="store_true", 
                 help="Legacy option to not parse SRR IDs (now default)")
@@ -131,7 +137,7 @@ def get_sra_acc_metadata(pacc, loc = '', list_only = False, no_SRR_parsing = Tru
         # otherwise, return all the Run accessions associated with whatever identifier was passed.
         return run_list, metadata_agg
 
-def run_fasterq_dump(acc, retries = 2, threads = 1, loc='', force=False, fastqdump=False, zip_func="gzip"):
+def run_fasterq_dump(acc, retries = 2, threads = 1, loc='', force=False, fastqdump=False, custom_args=[], zip_func="gzip"):
     """
     Helper function to run fast(er)q-dump to grab a particular `acc`ession,
     with support for a particular number of `retries`. Can use multiple
@@ -147,15 +153,18 @@ def run_fasterq_dump(acc, retries = 2, threads = 1, loc='', force=False, fastqdu
                 skip = True
                 break
         if not skip:
-            if fastqdump: # use legacy fastq-dump
-                print("downloading " + acc + " using fastq-dump")
-                cmd = ["fastq-dump", "--gzip", "--split-3", "--skip-technical"]
+            if len(custom_args) == 0:
+                if fastqdump: # use legacy fastq-dump
+                    cmd = ["fastq-dump", "--gzip", "--split-3", "--skip-technical"]
+                else:
+                    cmd = ["fasterq-dump", "-e", str(threads), "-f", "-3"]
             else:
-                print("downloading " + acc + " using fasterq-dump")
-                cmd = ["fasterq-dump", "-e", str(threads), "-f", "-3"]
+                prog_to_run = "fast" + "er"*(not fastqdump) + "q-dump"
+                cmd = [prog_to_run] + custom_args
             if loc != "":
                 cmd = cmd + ['-O', loc]
             cmd = cmd + [acc]
+            print("running: "+" ".join(cmd))
             retcode = call(cmd)
             rgzip = 0
             if retcode == 0:

--- a/grabseqslib/sra.py
+++ b/grabseqslib/sra.py
@@ -74,7 +74,7 @@ def add_sra_subparser(subparser):
     parser_sra.add_argument("--use_fastq_dump", dest="fastqdump", action="store_true",
                 help="use legacy fastq-dump instead of fasterq-dump (no multithreaded downloading)")
     parser_sra.add_argument("--custom_fqdump_args", dest="custom_fqd_args", type=str, default="",
-                help="pass unknown args to fast(er)q-dump. NOTE: Use full arg names\nfrom sra-tools to avoid conflicts!")
+                help="'string' containing args to pass to fast(er)q-dump")
 
     # LEGACY: this will be removed in the next major version as this is now default.
     parser_sra.add_argument('--no_parsing', dest="no_SRR_parsing", action="store_true", 

--- a/grabseqslib/sra.py
+++ b/grabseqslib/sra.py
@@ -157,7 +157,10 @@ def run_fasterq_dump(acc, retries = 2, threads = 1, loc='', force=False, fastqdu
                 else:
                     cmd = ["fasterq-dump", "-e", str(threads), "-f", "-3"]
             else:
-                prog_to_run = "fast" + "er"*(not fastqdump) + "q-dump"
+                suffix = "er"
+                if fastqdump:
+                    suffix = ""
+                prog_to_run = "fast" + suffix + "q-dump"
                 cmd = [prog_to_run] + custom_args.split(' ')
             if loc != "":
                 cmd = cmd + ['-O', loc]

--- a/grabseqslib/sra.py
+++ b/grabseqslib/sra.py
@@ -169,10 +169,9 @@ def run_fasterq_dump(acc, retries = 2, threads = 1, loc='', force=False, fastqdu
             retcode = call(cmd)
             rgzip = 0
             if retcode == 0:
-                if not fastqdump:
-                    # zip all possible output files for that acc
-                    fnames = build_paths(acc, loc, False) + build_paths(acc, loc, True)
-                    rgzip = gzip_files(fnames, zip_func, threads)
+                # zip all possible output files for that acc
+                fnames = build_paths(acc, loc, False) + build_paths(acc, loc, True)
+                rgzip = gzip_files(fnames, zip_func, threads)
 
                 if rgzip == 0:
                     if check_existing(loc, acc) != False:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 from distutils.core import setup
 
 setup(name='grabseqs',
-	version='0.6.1',
+	version='0.7.0',
 	description='Easily download reads from next-gen sequencing repositories like NCBI SRA',
 	author='Louis J Taylor',
 	author_email='l'+'ouist'+'@'+'u'+'penn.edu',

--- a/tests/test_general.bash
+++ b/tests/test_general.bash
@@ -10,7 +10,7 @@ function test_grabseqs_no_sratools {
     if grabseqs sra -o $TMPDIR/test_no_sra-tools ERR2279063; then
         exit 1
     fi
-    conda install sra-tools>2.9 -c bioconda -qy
+    conda install sra-tools=2.9 -c bioconda -qy
 }
 
 # test missing pigz

--- a/tests/test_general.bash
+++ b/tests/test_general.bash
@@ -10,7 +10,7 @@ function test_grabseqs_no_sratools {
     if grabseqs sra -o $TMPDIR/test_no_sra-tools ERR2279063; then
         exit 1
     fi
-    conda install sra-tools -c bioconda -qy
+    conda install sra-tools>2.9 -c bioconda -qy
 }
 
 # test missing pigz

--- a/tests/test_sra.bash
+++ b/tests/test_sra.bash
@@ -48,7 +48,7 @@ function test_sra_paired_fastqdump {
 }
 
 # test no clobber
-function test_sra_paired_no_clobber {
+function test_sra_no_clobber {
     t=`grabseqs sra -t 2 -o $TMPDIR/test_fastqdump_sra ERR2279063`
     echo $t
     if [[ $t != *"Pass -f to force download"* ]] ; then
@@ -57,10 +57,23 @@ function test_sra_paired_no_clobber {
 }
 
 # test force
-function test_sra_paired_forced {
+function test_sra_forced {
     tf=`grabseqs sra -t 2 -o $TMPDIR/test_fastqdump_sra -f ERR2279063`
     echo $tf
     if [[ $tf == *"Pass -f to force download"* ]] ; then
         exit 1
     fi
 }
+
+# test custom args to fasterq-dump (#44)
+function test_sra_custom_fasterqdump_args {
+    grabseqs sra ERR2279063 -o $TMPDIR/test_fasterqdump_custom --custom_fqdump_args "-f -3"
+    ls $TMPDIR/test_fasterqdump_custom/ERR2279063.fastq.gz
+}
+
+# test custom args to fastq-dump
+function test_sra_custom_fastqdump_args {
+    grabseqs sra ERR2279063 --use_fastq_dump -o $TMPDIR/test_fastqdump_custom --custom_fqdump_args "--gzip --split-3 --skip-technical"
+    ls $TMPDIR/test_fastqdump_custom/ERR2279063.fastq.gz
+}
+

--- a/tests/test_sra.bash
+++ b/tests/test_sra.bash
@@ -67,14 +67,14 @@ function test_sra_forced {
 
 # test custom args to fasterq-dump (#44)
 function test_sra_custom_fasterqdump_args {
-    grabseqs sra SRR1913936 -o $TMPDIR/test_fasterqdump_custom --custom_fqdump_args='--split-spot'
+    grabseqs sra SRR1913936 -r 0 -o $TMPDIR/test_fasterqdump_custom --custom_fqdump_args='--split-spot'
     # this is a paired run, but with `--split-spot` instead of `--split-3` it should come down as a single interleaved fastq.gz
     ls $TMPDIR/test_fasterqdump_custom/SRR1913936.fastq.gz
 }
 
 # test custom args to fastq-dump (#44)
 function test_sra_custom_fastqdump_args {
-    grabseqs sra SRR1913936 --use_fastq_dump -o $TMPDIR/test_fastqdump_custom --custom_fqdump_args='--gzip --skip-technical'
+    grabseqs sra SRR1913936 -r 0 --use_fastq_dump -o $TMPDIR/test_fastqdump_custom --custom_fqdump_args='--gzip --skip-technical'
     # this is a paired run, but without the `--split-3` arg it should come down as a single interleaved fastq.gz
     ls $TMPDIR/test_fastqdump_custom/SRR1913936.fastq.gz
 }

--- a/tests/test_sra.bash
+++ b/tests/test_sra.bash
@@ -67,15 +67,15 @@ function test_sra_forced {
 
 # test custom args to fasterq-dump (#44)
 function test_sra_custom_fasterqdump_args {
-#    newargs="-f -3"
-#    echo runnin with $newargs
-    grabseqs sra ERR2279063 -o $TMPDIR/test_fasterqdump_custom --custom_fqdump_args -f -3
-    ls $TMPDIR/test_fasterqdump_custom/ERR2279063.fastq.gz
+    grabseqs sra SRR1913936 -o $TMPDIR/test_fasterqdump_custom --custom_fqdump_args='--split-spot'
+    # this is a paired run, but with `--split-spot` instead of `--split-3` it should come down as a single interleaved fastq.gz
+    ls $TMPDIR/test_fasterqdump_custom/SRR1913936.fastq.gz
 }
 
-# test custom args to fastq-dump
+# test custom args to fastq-dump (#44)
 function test_sra_custom_fastqdump_args {
-    grabseqs sra ERR2279063 --use_fastq_dump -o $TMPDIR/test_fastqdump_custom --custom_fqdump_args "'--gzip --split-3 --skip-technical'"
-    ls $TMPDIR/test_fastqdump_custom/ERR2279063.fastq.gz
+    grabseqs sra SRR1913936 --use_fastq_dump -o $TMPDIR/test_fastqdump_custom --custom_fqdump_args='--gzip --skip-technical'
+    # this is a paired run, but without the `--split-3` arg it should come down as a single interleaved fastq.gz
+    ls $TMPDIR/test_fastqdump_custom/SRR1913936.fastq.gz
 }
 

--- a/tests/test_sra.bash
+++ b/tests/test_sra.bash
@@ -11,7 +11,6 @@ function test_sra_metadata_downloaded {
     if [ `cat $TMPDIR/test_metadata/SRP057027.tsv | wc -l` -ne 370 ] ; then
         exit 1
     fi
-    #echo -e "$PASS SRA metadata test passed"
 }
 
 # test behavior with -l and --no_parsing
@@ -58,7 +57,7 @@ function test_sra_no_clobber {
 
 # test force
 function test_sra_forced {
-    tf=`grabseqs sra -t 2 -o $TMPDIR/test_fastqdump_sra -f ERR2279063`
+    tf=`grabseqs sra -r 0 -t 2 -o $TMPDIR/test_fastqdump_sra -f ERR2279063`
     echo $tf
     if [[ $tf == *"Pass -f to force download"* ]] ; then
         exit 1

--- a/tests/test_sra.bash
+++ b/tests/test_sra.bash
@@ -67,13 +67,15 @@ function test_sra_forced {
 
 # test custom args to fasterq-dump (#44)
 function test_sra_custom_fasterqdump_args {
-    grabseqs sra ERR2279063 -o $TMPDIR/test_fasterqdump_custom --custom_fqdump_args "-f -3"
+#    newargs="-f -3"
+#    echo runnin with $newargs
+    grabseqs sra ERR2279063 -o $TMPDIR/test_fasterqdump_custom --custom_fqdump_args -f -3
     ls $TMPDIR/test_fasterqdump_custom/ERR2279063.fastq.gz
 }
 
 # test custom args to fastq-dump
 function test_sra_custom_fastqdump_args {
-    grabseqs sra ERR2279063 --use_fastq_dump -o $TMPDIR/test_fastqdump_custom --custom_fqdump_args "--gzip --split-3 --skip-technical"
+    grabseqs sra ERR2279063 --use_fastq_dump -o $TMPDIR/test_fastqdump_custom --custom_fqdump_args "'--gzip --split-3 --skip-technical'"
     ls $TMPDIR/test_fastqdump_custom/ERR2279063.fastq.gz
 }
 


### PR DESCRIPTION
This PR adds a new feature suggested by a reviewer of the grabseqs manuscript--the ability for the user to pass custom arguments to fasterq-dump. This PR closes #44. This functionality will be released in v0.7.0.