### PR TITLE
Properly handle accession numbers which aren't associated with samples

### DIFF
--- a/grabseqslib/sra.py
+++ b/grabseqslib/sra.py
@@ -95,8 +95,8 @@ def get_sra_acc_metadata(pacc, loc = '', list_only = False, no_SRR_parsing = Tru
     lines = [l.split(',') for l in metadata.text.split("\n")]
     try:
         run_col = lines[0].index("Run")
-    except IndexError: # "Run" column always present unless search failed
-        raise IndexError("Could not find samples for accession: "+pacc+". If this accession number is valid, try re-running.")
+    except ValueError: # "Run" column always present unless search failed
+        raise ValueError("Could not find samples for accession: "+pacc+". If this accession number is valid, try re-running.")
 
     # Generate list of runs to download
     run_list = [l[run_col] for l in lines[1:] if len(l[run_col]) > 0]

--- a/tests/test_imicrobe.bash
+++ b/tests/test_imicrobe.bash
@@ -54,3 +54,10 @@ function test_imicrobe_fasta_force {
     fi
     ls $TMPDIR/test_tiny_im/s710.fastq.gz
 }
+
+# test case for invalid/empty accessions--should raise error (#51)
+function test_imicrobe_invalid_acc {
+    if grabseqs mgrast -l p4fake; then
+        exit 1
+    fi
+}

--- a/tests/test_mgrast.bash
+++ b/tests/test_mgrast.bash
@@ -44,3 +44,9 @@ function test_mgrast_fastq_force_download {
     ls $TMPDIR/test_tiny_mg/mgm4793571.3.fastq.gz
 }
 
+# test case for invalid/empty accessions--should raise error (#51)
+function test_mgrast_invalid_acc {
+    if grabseqs mgrast -l mgp0fake; then
+        exit 1
+    fi
+}

--- a/tests/test_sra.bash
+++ b/tests/test_sra.bash
@@ -78,3 +78,9 @@ function test_sra_custom_fastqdump_args {
     ls $TMPDIR/test_fastqdump_custom/SRR1913936.fastq.gz
 }
 
+# test case for invalid/empty accessions--should raise error (#51)
+function test_sra_invalid_acc {
+    if grabseqs sra -l PRJNAXXXXXXXX; then
+        exit 1
+    fi
+}


### PR DESCRIPTION
This PR fixes #51. We were attempting to catch an `IndexError`, but a `ValueError` was being thrown. Not sure why I did that in the first place :D